### PR TITLE
CFGMarker error

### DIFF
--- a/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/pfz.sqf
+++ b/@AH-64D Apache Longbow/Addons/fza_ah64_controls/scripting/pfz.sqf
@@ -53,7 +53,7 @@ _markerarea setMarkerColorLocal "ColorWhite";
 
 createmarkerlocal [_markername,[_xpos,_ypos]];
 _markername setMarkerShapeLocal "ICON";
-_markername setMarkerTypeLocal "DOT";
+_markername setMarkerTypeLocal "mil_dot";
 _markername setMarkerTextLocal "PFZ" + format ["%1",_pfznum];
 _markername setMarkerColorLocal "ColorBlack";
 


### PR DESCRIPTION
When placing an PFZ error on screen ref marker "DOT". Changed to A3 standard "mil_dot".